### PR TITLE
Fix unknown response type error

### DIFF
--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -2351,7 +2351,7 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                             }
                             self._set_cached_data(cache_key, result)
                             return result
-                        elif response_data.get("request_type") in ["get_entities", "get_entities_by_area"]:
+                        elif response_data.get("request_type") in ["get_entities", "get_entities_by_area", "get_entities_by_domain"]:
                             # Handle direct get_entities request (for backward compatibility)
                             parameters = response_data.get("parameters", {})
                             _LOGGER.debug("Processing direct get_entities request with parameters: %s", json.dumps(parameters))
@@ -2368,8 +2368,10 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                                     area_id=parameters.get("area_id"),
                                     area_ids=parameters.get("area_ids")
                                 )
-                            else:  # get_entities_by_area
+                            elif response_data.get("request_type") == "get_entities_by_area":
                                 data = await self.get_entities_by_area(parameters.get("area_id"))
+                            else:  # get_entities_by_domain
+                                data = await self.get_entities_by_domain(parameters.get("domain"))
                             
                             _LOGGER.debug("Retrieved %d entities", len(data) if isinstance(data, list) else 1)
                             


### PR DESCRIPTION
Add `get_entities_by_domain` to supported response types and implement its handling logic.

The `get_entities_by_domain` function was correctly implemented, but the response handling logic in `agent.py` was missing a case to process this specific request type, leading to an "Unknown response type" error.